### PR TITLE
Explicitly disable "Keep Alives" in our Docker communications

### DIFF
--- a/src/cmd/rawdns/docker.go
+++ b/src/cmd/rawdns/docker.go
@@ -50,6 +50,7 @@ func dockerInspectContainer(dockerHost, containerName string) (*dockerContainer,
 
 func httpClient(u *url.URL) *http.Client {
 	transport := &http.Transport{}
+	transport.DisableKeepAlives = true
 	switch u.Scheme {
 	case "tcp":
 		u.Scheme = "http"


### PR DESCRIPTION
Fixes #4
Fixes #8

I've been testing this with the following in 5 terminals at once which used to spike our memory usage trivially and very quickly, and it appears to have worked flawlessly as the fix!  Thanks @sbodomerle!

```console
$ yes rawdns.docker | head -n1000 | xargs watch --interval=0.01 dig
```