### PR TITLE
Implement domain name rewriting support.

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -1,7 +1,8 @@
 {
 	"docker.": {
 		"type": "containers",
-		"socket": "unix:///var/run/docker.sock"
+		"socket": "unix:///var/run/docker.sock",
+		"rewrite": { "^(.*)\\.prod$": "prod_$1" }
 	},
 	".": {
 		"type": "forwarding",


### PR DESCRIPTION
Implement domain name rewriting support.

This patch adds 'rewrite' configuration dict for the 'docker'
section, containing pairs "regexp: replace". This can be useful
in setups where an automated tooling (e.g. docker-compose)
creates sets of containers with common naming scheme that can
be translated to a more-useful namepace, e.g.:

  service.prod.docker. -> prod_service

Each name resolution request is rewritten by all these rules.
Since the map in Go does not have a deterministic ordering, it is
expected that at most one regexp matches can match any domain
name.

Signed-off-by: Milan Plzik <milan.plzik@gmail.com>
