### PR TITLE
WIP: Add support for swarm-mode (1.12)

### DIFF
--- a/src/cmd/rawdns/docker.go
+++ b/src/cmd/rawdns/docker.go
@@ -11,6 +11,9 @@ import (
 
 var (
 	dockerApiVersions = []string{
+		// swarm mode was added in 1.24.
+		"v1.24",
+
 		// libnetwork doesn't provide "Networks" until at least API version 1.21
 		"v1.21",
 
@@ -56,13 +59,53 @@ type dockerContainer struct {
 	}
 }
 
-func dockerGetIpList(dockerHost, containerName string, tlsConfig *tls.Config, swarmNode bool) ([]net.IP, error) {
+type dockerService struct {
+	ID      string
+	Version struct {
+		Index int
+	}
+	CreatedAt string
+	UpdatedAt string
+	Spec      struct {
+		Name string
+	}
+	Endpoint struct {
+		VirtualIps []struct {
+			NetworkID string
+			Addr      string
+		}
+	}
+}
+
+func dockerGetIpList(dockerHost, domainPrefixOrContainerName string, tlsConfig *tls.Config, swarmNode bool, swarmMode bool) ([]net.IP, error) {
 	var (
 		container *dockerContainer
+		service   *dockerService
 		err       error
 	)
+
 	for _, apiVersion := range dockerApiVersions {
-		container, err = dockerInspectContainer(dockerHost, containerName, tlsConfig, apiVersion)
+		if swarmMode {
+			service, err = dockerInspectService(dockerHost, domainPrefixOrContainerName, tlsConfig, apiVersion)
+			if err != nil {
+				continue
+			}
+
+			ips := []net.IP{}
+			for _, vip := range service.Endpoint.VirtualIps {
+				ip, _, err := net.ParseCIDR(vip.Addr)
+				if err != nil {
+					return nil, err
+				}
+
+				ips = append(ips, ip)
+
+				// TODO: Maybe discover tasks and add their ips?
+			}
+
+			return ips, nil
+		}
+		container, err = dockerInspectContainer(dockerHost, domainPrefixOrContainerName, tlsConfig, apiVersion)
 		if err != nil {
 			continue
 		}
@@ -118,6 +161,32 @@ func dockerInspectContainer(dockerHost, containerName string, tlsConfig *tls.Con
 		return nil, fmt.Errorf("not '200 OK': %v", resp.Status)
 	}
 	ret := dockerContainer{}
+	err = json.NewDecoder(resp.Body).Decode(&ret)
+	if err != nil {
+		return nil, fmt.Errorf("failed decoding JSON response: %v", err)
+	}
+	return &ret, nil
+}
+
+func dockerInspectService(dockerHost, containerName string, tlsConfig *tls.Config, apiVersion string) (*dockerService, error) {
+	u, err := url.Parse(dockerHost)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing URL '%s': %v", dockerHost, err)
+	}
+	client := httpClient(u, tlsConfig)
+	req, err := http.NewRequest("GET", u.String()+"/"+apiVersion+"/services/"+containerName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("not '200 OK': %v", resp.Status)
+	}
+	ret := dockerService{}
 	err = json.NewDecoder(resp.Body).Decode(&ret)
 	if err != nil {
 		return nil, fmt.Errorf("failed decoding JSON response: %v", err)


### PR DESCRIPTION
Note: This is my first time doing go-programming, so please be kind :)

Will add some documentation on how to use this after I verified that it works for my use case. My plan is to integrate this into a swarm mode (1.12) cluster to be able to "hook" some domain suffixes to my containers (mainly for swarm internal tls certificate verification to work).

Note: https://github.com/tianon/rawdns/issues/15 would be nice to have for my use-case as well :)